### PR TITLE
Adding P4 support to ForkMergeParser + output an additional information

### DIFF
--- a/src/superc/core/ForkMergeParser.java
+++ b/src/superc/core/ForkMergeParser.java
@@ -2062,7 +2062,6 @@ public class ForkMergeParser {
           subparser.presenceCondition.delRef();
           subparser.presenceCondition = or;
         }
-
         // // Combine the subparsers' presence conditions.
         // PresenceCondition disjunction = subparser.presenceCondition;
         // for (Subparser mergedParser : mergedParsers) {
@@ -2110,6 +2109,7 @@ public class ForkMergeParser {
 
     return subset;
   }
+
 
   /**
    * Fork subparser on a set of tokens.
@@ -2520,16 +2520,24 @@ public class ForkMergeParser {
     }
 
     if (conditionGranularity
-        && conditionalInside
-        && trackedProductions.contains(nodeName)) {
+        && (emitConditionalAfterSet || conditionalInside)
+        && (trackAllProductions || trackedProductions.contains(nodeName))) {
       // Location location = getProductionLocation(value);
       Location location = getProductionLocation(value);
 
       // Emit the marker.
+      if(conditionalInside) {
       System.err.println(String.format("conditional_inside %s %s \"%s\"",
                                        nodeName,
                                        location,
                                        joinSet(insideSet, ",")));
+      }
+      else if (emitConditionalAfterSet && conditionalAfter) {
+        System.err.println(String.format("conditional_after %s %s \"%s\"",
+                                        nodeName,
+                                        location,
+                                        joinSet(afterSet, ",")));
+      }
     }
 
     if (hasSemanticActions) {
@@ -3082,7 +3090,6 @@ public class ForkMergeParser {
       int flags
         = (null != this.value ? 1 : 0)
         | (null != other.value ? 2 : 0);
-
       // System.err.println("MERGE BEFORE");
       // System.err.println(this.value);
       // System.err.println(thisPresenceCondition);
@@ -3191,7 +3198,7 @@ public class ForkMergeParser {
         this.next.merge(thisPresenceCondition, other.next,otherPresenceCondition, dist - 1);
       }
     }
-    
+
     /**
      * Get the string representation.
      *
@@ -3288,3 +3295,4 @@ public class ForkMergeParser {
     return ret;
   }
 }
+


### PR DESCRIPTION
Adding P4 support to ForkMergeParser in a language independent way. Added an overloaded `conditionGranularity` function that will be used by SuperP4.java to set `conditionGranularity` flag and two new flags: one to track all productions under the conditional granularity option (rather than check if the production is part of the `trackedProductions` variable), and to emit the conditional after-set. The latter is to emit the conditional after-set of productions (when conditionGranularity is enabled) during the reduction stage when then conditional inside-set of productions is empty but not the after-set (since there were some cases where the conditional inside-set did not contain the production that had a conditional inside it but the after-set did).