### PR TITLE
Inform user when a guarded header file is encountered

### DIFF
--- a/src/superc/core/HeaderFileManager.java
+++ b/src/superc/core/HeaderFileManager.java
@@ -439,7 +439,7 @@ public class HeaderFileManager implements Iterator<Syntax> {
     if (guarded) {
 
       // No need to even open the header file.  It is guarded.
-
+      if(showHeaders) System.err.println("guarded header file: " + header.name);
       return true;
     }
 


### PR DESCRIPTION
In addition to informing the user when entering a header file, the showHeaders flag will also now inform the user when encountering a guarded header file (case where it will not enter the header file since it was already included/encountered in the source program). 