### PR TITLE
Preprocessor: fix null check

### DIFF
--- a/src/superc/core/Preprocessor.java
+++ b/src/superc/core/Preprocessor.java
@@ -4106,8 +4106,7 @@ public class Preprocessor implements Iterator<Syntax> {
                 // feature.  When an empty variaidic argument is
                 // pasted with a comma, the comma is removed.  If the
                 // variadic is not empty, no pasting occurs.
-
-                if (args.size() == f.formals.size()) {
+                if (null != f.formals && args.size() == f.formals.size()) {
                   // Swallow the comma (don't add it to the expanded
                   // definition.)  Then skip the variadic argument
                   // since we know it's empty.


### PR DESCRIPTION
I am not sure if this is a semantically correct fix: `f.formals` being `null` at that line might be due to another bug before this line.

If correct: fixes https://github.com/appleseedlab/xtc-dev/issues/153